### PR TITLE
Fix: `PackageNotFoundError` when running `--version` from the binary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "nuitka.distutils.Build"
 
 [project]
 name = "kachi"
-version = "0.1.1"
+dynamic = ["version"]
 requires-python = ">=3.12"
 authors = [{ name = "Ricky White", email = "ricky@rickywhite.net" }]
 maintainers = [{ name = "Ricky White", email = "ricky@rickywhite.net" }]

--- a/src/kachi/__init__.py
+++ b/src/kachi/__init__.py
@@ -2,5 +2,7 @@
 
 import logging
 
+__version__ = "0.1.1"
+
 logging.basicConfig(level=logging.INFO, format="%(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)

--- a/src/kachi/cli.py
+++ b/src/kachi/cli.py
@@ -1,10 +1,9 @@
-import importlib.metadata
-import logging
 from pathlib import Path
 
 import typer
 from typing_extensions import Annotated
 
+from kachi import __version__ as kachi_version
 from kachi import logger
 from kachi.backup import backup_profile
 from kachi.config import Config
@@ -14,8 +13,7 @@ app = typer.Typer(no_args_is_help=True)
 
 def get_version(value: bool):
     if value:
-        version = importlib.metadata.version("kachi")
-        print(f"kachi v{version}")
+        print(f"kachi v{kachi_version}")
         raise typer.Exit()
 
 
@@ -36,7 +34,7 @@ def backup(
     profile: Annotated[str, typer.Option(help="Name of the profile to backup")] = "",
 ):
     """Backup files and directories.
-    
+
     If no profile is specified, all profiles in the configuration file
     will be backed up. If no configuration file is specified, the
     default configuration file path will be used.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+from kachi import __version__
 from kachi.cli import app
 from typer.testing import CliRunner
 
@@ -9,3 +10,4 @@ class TestCli:
         result = runner.invoke(app, ["--version"])
         assert result.exit_code == 0
         assert "kachi" in result.stdout
+        assert __version__ in result.stdout


### PR DESCRIPTION
Move the version number from `pyproject.toml` to `kachi/__init__.py`. This allows the `--version` tag to pull directly from the `__version__` variable.

