### PR TITLE
ci: Add explicit read-only permissions to CI workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration files to explicitly set permissions for the workflows. The main change is the addition of a `permissions` block to both the linting and testing workflows, ensuring that the workflows only have read access to repository contents.

Workflow permissions updates:

* Added a `permissions` block with `contents: read` to `.github/workflows/lint.yml` to restrict workflow permissions to read-only access.
* Added a `permissions` block with `contents: read` to `.github/workflows/test.yml` to restrict workflow permissions to read-only access.